### PR TITLE
Fix typos and remove spaces at end of lines and use codecs.

### DIFF
--- a/check_crl/README.md
+++ b/check_crl/README.md
@@ -5,12 +5,12 @@ This is a nagios plugin which you can use to check if a CRL (Certificate Revocat
 
 #### Download
 
-[Download the plugin from my github](https://github.com/RaymiiOrg/nagios)  
-[Download the plugin from raymii.org](https://raymii.org/s/inc/downloads/check_crl.py)  
+[Download the plugin from my github](https://github.com/RaymiiOrg/nagios)
+[Download the plugin from raymii.org](https://raymii.org/s/inc/downloads/check_crl.py)
 
 #### Install and Usage
 
-This guide covers the steps needed for Ubuntu 10.04/12.04 and Debian 6. It should also work on other distro's, but make sure to modify the commands where needed. 
+This guide covers the steps needed for Ubuntu 10.04/12.04 and Debian 6. It should also work on other distro's, but make sure to modify the commands where needed.
 
 Make sure you have openssl, python3 and a module needed by the script installed on the nagios host:
 
@@ -27,13 +27,13 @@ Make sure the script is executable:
 Now test the script. I'm using the URL of the Comodo CA CRL file which is the CA that signed my certificate for raymii.org.
 
 
-    /etc/nagios/plugins/check_crl.py -h http://crl.comodoca.com/PositiveSSLCA2.crl -w 480 -c 360
+    /etc/nagios/plugins/check_crl.py -u http://crl.comodoca.com/PositiveSSLCA2.crl -w 480 -c 360
     OK CRL Expires in 5109 minutes (on Thu May  9 07:30:32 2013 GMT)
 
-    /etc/nagios/plugins/check_crl.py -h http://crl.comodoca.com/PositiveSSLCA2.crl -w 5200 -c 360
+    /etc/nagios/plugins/check_crl.py -u http://crl.comodoca.com/PositiveSSLCA2.crl -w 5200 -c 360
     WARNING CRL Expires in 5108 minutes (on Thu May  9 07:30:32 2013 GMT)
 
-    /etc/nagios/plugins/check_crl.py -h http://crl.comodoca.com/PositiveSSLCA2.crl -w 5000 -c 5300
+    /etc/nagios/plugins/check_crl.py -u http://crl.comodoca.com/PositiveSSLCA2.crl -w 5000 -c 5300
     CRITICAL CRL Expires in 5108 minutes (on Thu May  9 07:30:32 2013 GMT)
 
 Lets add the nagios command:
@@ -49,13 +49,16 @@ And lets add the command to a service check:
             use                             generic-service
             host_name                       localhost
             service_description             Comodo PositiveSSL CA2 CRL
-            contact                         nagiosadmin                 
+            contact                         nagiosadmin
             check_command                   crl_check!http://crl.comodoca.com/PositiveSSLCA2.crl!24!12
     }
 
 The above service check runs on the nagios defined host "localhost", uses the (default) service template "generic-service" and had the contact "nagiosadmin". As you can see, the URL maps to $ARG1$, the warning hours to $ARG2$ and the critical hours to $ARG3$. This means that if the field *"Next Update:"* is less then 8 hours in the future you get a warning and if it is less then 6 hours you get a critical.
 
 #### Changelog
+09-14-2019:
+- Fix typos in examples.
+- Remove spaces from end of lines
 
 03-04-2013:
 - Changed time to minutes for more precision


### PR DESCRIPTION
When read binary CRL file, got 'utf-8' error.
It can be fixed with `codecs`.

And also removed spaces end of lines and remove description on `verbose` in help message.